### PR TITLE
feat: multi-event support with dirty CSV handling

### DIFF
--- a/app/[slug]/admin/page.tsx
+++ b/app/[slug]/admin/page.tsx
@@ -1,0 +1,132 @@
+import { cookies } from 'next/headers'
+import Image from 'next/image'
+import Link from 'next/link'
+import { notFound } from 'next/navigation'
+import { eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { events } from '@/lib/db/schema'
+import { getAdminCookieName, verifyAdminToken } from '@/lib/admin'
+import {
+  adminLogin,
+  adminLogout,
+  uploadEmailsCsv,
+  uploadCodesCsv,
+  upsertAllowedEmail,
+  deleteAllowedEmail,
+  pasteCodesRaw
+} from '../../admin/actions'
+import { AdminAnalytics } from '../../admin/admin-analytics'
+import { AdminLoginForm } from '../../admin/admin-login-form'
+import { EmailManager } from '../../admin/email-manager'
+import { AdminQueryProvider } from '../../admin/query-provider'
+import { CsvUpload } from '../../admin/csv-upload'
+import { PasteCodes } from '../../admin/paste-codes'
+
+export default async function EventAdminPage ({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const [event] = await db.select().from(events).where(eq(events.slug, slug)).limit(1)
+
+  if (!event) {
+    notFound()
+  }
+
+  const cookieStore = await cookies()
+  const token = cookieStore.get(getAdminCookieName())?.value
+  const isAdmin = await verifyAdminToken(token)
+
+  if (!isAdmin) {
+    return (
+      <div className="flex min-h-screen flex-col items-center justify-center bg-[#1a1a1a] px-4 py-16 font-sans text-white">
+        <main className="w-full max-w-sm">
+          <Image
+            src="/CUBE_2D_DARK.png"
+            alt="Cursor Kenya"
+            width={48}
+            height={48}
+            className="mx-auto mb-6"
+          />
+          <h1 className="mb-6 text-center text-xl font-bold text-zinc-100">
+            Admin — {event.name}
+          </h1>
+          <AdminLoginForm action={adminLogin} redirectTo={`/${slug}/admin`} />
+          <p className="mt-6 text-center text-xs text-zinc-500">
+            <Link href={`/${slug}`} className="underline hover:text-zinc-400">
+              Back to event
+            </Link>
+          </p>
+        </main>
+      </div>
+    )
+  }
+
+  return (
+    <div className="min-h-screen bg-[#1a1a1a] px-4 py-12 font-sans text-white">
+      <div className="mx-auto max-w-5xl">
+        <AdminQueryProvider>
+          <header className="mb-8 flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-3">
+              <Image
+                src="/CUBE_2D_DARK.png"
+                alt="Cursor Kenya"
+                width={40}
+                height={40}
+              />
+              <div>
+                <h1 className="text-2xl font-bold tracking-tight text-zinc-100">
+                  {event.name}
+                </h1>
+                <p className="mt-1 text-sm text-zinc-400">
+                  Manage codes, emails, and CSV uploads
+                </p>
+              </div>
+            </div>
+            <div className="flex items-center gap-3">
+              <PasteCodes action={pasteCodesRaw} eventSlug={slug} />
+              <form action={adminLogout}>
+                <input type="hidden" name="redirectTo" value={`/${slug}/admin`} />
+                <button
+                  type="submit"
+                  className="rounded-lg border border-zinc-600 bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
+                >
+                  Log out
+                </button>
+              </form>
+            </div>
+          </header>
+
+          <div className="space-y-8">
+            <EmailManager
+              upsertAction={upsertAllowedEmail}
+              deleteAction={deleteAllowedEmail}
+              eventSlug={slug}
+            />
+            <div className="grid gap-4 sm:grid-cols-2">
+              <CsvUpload
+                action={uploadEmailsCsv}
+                label="Bulk Upload Emails"
+                hint="Columns: email, name (or one email per line)."
+                eventSlug={slug}
+              />
+              <CsvUpload
+                action={uploadCodesCsv}
+                label="Bulk Upload Codes (CSV)"
+                hint="Auto-detects codes, URLs, or CSV with code/url columns."
+                eventSlug={slug}
+              />
+            </div>
+            <AdminAnalytics eventSlug={slug} />
+          </div>
+        </AdminQueryProvider>
+
+        <div className="mt-8 flex justify-center gap-4 text-xs text-zinc-500">
+          <Link href={`/${slug}`} className="underline hover:text-zinc-400">
+            Back to event
+          </Link>
+          <Link href="/admin" className="underline hover:text-zinc-400">
+            All events
+          </Link>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -1,0 +1,16 @@
+import { notFound } from 'next/navigation'
+import { eq } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { events } from '@/lib/db/schema'
+import { RedeemForm } from './redeem-form'
+
+export default async function EventPage ({ params }: { params: Promise<{ slug: string }> }) {
+  const { slug } = await params
+  const [event] = await db.select().from(events).where(eq(events.slug, slug)).limit(1)
+
+  if (!event) {
+    notFound()
+  }
+
+  return <RedeemForm eventSlug={event.slug} eventName={event.name} />
+}

--- a/app/[slug]/redeem-form.tsx
+++ b/app/[slug]/redeem-form.tsx
@@ -1,0 +1,101 @@
+'use client'
+
+import Image from 'next/image'
+import Link from 'next/link'
+import { useActionState } from 'react'
+import { redeemCode, type RedeemResult } from '../actions/redeem'
+
+export function RedeemForm ({ eventSlug, eventName }: { eventSlug: string; eventName: string }) {
+  const [result, formAction, isPending] = useActionState(redeemCode, null as RedeemResult | null)
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-[#1a1a1a] px-4 py-16 font-sans text-white">
+      <main className="flex w-full max-w-md flex-col items-center gap-8">
+        <div className="flex flex-col items-center gap-4">
+          <Image
+            src="/CUBE_2D_DARK.png"
+            alt="Cursor Kenya"
+            width={56}
+            height={56}
+            className="mx-auto"
+          />
+          <h1
+            className="text-center text-2xl font-bold tracking-tight"
+            style={{ fontFamily: 'var(--font-geist-pixel-square)' }}
+          >
+            {eventName}
+          </h1>
+          <p className="text-center text-sm font-normal text-zinc-400">
+            Redeem your Cursor Pro access code
+          </p>
+        </div>
+
+        <div className="flex w-full flex-col items-center gap-6">
+          <p className="text-center text-sm text-zinc-400">
+            Kindly use the same email you RSVPed with on Luma.
+            <br />
+            It can be a separate email from the one associated with your Cursor account.
+          </p>
+
+          {result?.success && (
+            <div className="w-full rounded-lg border border-green-600/60 bg-green-900/20 px-4 py-3 text-sm text-green-300">
+              <p className="font-medium">Code assigned successfully. A confirmation email was sent.</p>
+              <p className="mt-1 break-all">
+                <a
+                  href={result.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="underline hover:text-green-200"
+                >
+                  {result.url}
+                </a>
+              </p>
+              <p className="mt-1 text-zinc-400">Code: {result.code}</p>
+            </div>
+          )}
+
+          {result && !result.success && (
+            <div
+              className="w-full rounded-lg border border-red-600/60 bg-red-900/20 px-4 py-3 text-sm text-red-300"
+              role="alert"
+            >
+              {result.error}
+            </div>
+          )}
+
+          <form
+            action={formAction}
+            className="flex w-full flex-col gap-4"
+          >
+            <input type="hidden" name="eventSlug" value={eventSlug} />
+            <input
+              type="email"
+              name="email"
+              placeholder="Email"
+              className="w-full rounded-lg border border-zinc-600 bg-zinc-800/80 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
+              aria-label="Email"
+              required
+              disabled={isPending}
+            />
+            <button
+              type="submit"
+              disabled={isPending}
+              className="w-full rounded-lg bg-orange-500 py-3 font-semibold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] disabled:opacity-60"
+            >
+              {isPending ? 'Redeeming…' : 'Redeem Code'}
+            </button>
+          </form>
+        </div>
+
+        <div className="flex flex-col items-center gap-2">
+          <p className="text-center text-xs text-zinc-500">
+            cursor pro codes by cursor kenya community
+          </p>
+          <Link href="/" className="text-xs text-zinc-500 underline hover:text-zinc-400">
+            All events
+          </Link>
+        </div>
+      </main>
+    </div>
+  )
+}

--- a/app/actions/redeem.ts
+++ b/app/actions/redeem.ts
@@ -1,6 +1,6 @@
 'use server'
 
-import { eq, isNull } from 'drizzle-orm'
+import { and, eq, isNull } from 'drizzle-orm'
 import { db } from '@/lib/db'
 import { allowedEmails, referralCodes } from '@/lib/db/schema'
 import { sendRedemptionEmail } from '@/lib/email'
@@ -18,16 +18,21 @@ export async function redeemCode (
   formData: FormData
 ): Promise<RedeemResult> {
   const rawEmail = (formData.get('email') as string) ?? ''
+  const eventSlug = (formData.get('eventSlug') as string) ?? ''
   const email = normalizeEmail(rawEmail)
 
   if (!email || !email.includes('@')) {
     return { success: false, error: 'Please enter a valid email address.' }
   }
 
+  if (!eventSlug) {
+    return { success: false, error: 'Invalid event.' }
+  }
+
   const [allowed] = await db
     .select()
     .from(allowedEmails)
-    .where(eq(allowedEmails.email, email))
+    .where(and(eq(allowedEmails.email, email), eq(allowedEmails.eventSlug, eventSlug)))
     .limit(1)
 
   if (!allowed) {
@@ -37,7 +42,7 @@ export async function redeemCode (
   const [alreadyClaimed] = await db
     .select()
     .from(referralCodes)
-    .where(eq(referralCodes.claimedByEmail, email))
+    .where(and(eq(referralCodes.claimedByEmail, email), eq(referralCodes.eventSlug, eventSlug)))
     .limit(1)
 
   if (alreadyClaimed) {
@@ -47,7 +52,7 @@ export async function redeemCode (
   const [unclaimed] = await db
     .select()
     .from(referralCodes)
-    .where(isNull(referralCodes.claimedByEmail))
+    .where(and(isNull(referralCodes.claimedByEmail), eq(referralCodes.eventSlug, eventSlug)))
     .limit(1)
 
   if (!unclaimed) {
@@ -80,8 +85,10 @@ export async function redeemCode (
 
 export type CodeCounts = { available: number; total: number }
 
-export async function getCodeCounts (): Promise<CodeCounts> {
-  const all = await db.select().from(referralCodes)
-  const unclaimed = await db.select().from(referralCodes).where(isNull(referralCodes.claimedByEmail))
+export async function getCodeCounts (eventSlug: string): Promise<CodeCounts> {
+  const all = await db.select().from(referralCodes).where(eq(referralCodes.eventSlug, eventSlug))
+  const unclaimed = await db.select().from(referralCodes).where(
+    and(isNull(referralCodes.claimedByEmail), eq(referralCodes.eventSlug, eventSlug))
+  )
   return { total: all.length, available: unclaimed.length }
 }

--- a/app/admin/actions.ts
+++ b/app/admin/actions.ts
@@ -3,10 +3,10 @@
 import { cookies } from 'next/headers'
 import { redirect } from 'next/navigation'
 import { parse } from 'csv-parse/sync'
-import { eq, sql } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { validateAdminCredentials, getAdminCookieName, verifyAdminToken } from '@/lib/admin'
 import { db } from '@/lib/db'
-import { allowedEmails, referralCodes } from '@/lib/db/schema'
+import { events, allowedEmails, referralCodes } from '@/lib/db/schema'
 
 async function requireAdmin () {
   const cookieStore = await cookies()
@@ -19,6 +19,7 @@ async function requireAdmin () {
 export async function adminLogin (formData: FormData) {
   const username = (formData.get('username') as string | null)?.trim()
   const password = formData.get('password') as string | null
+  const redirectTo = (formData.get('redirectTo') as string) || '/admin'
   if (!username || !password) {
     return { error: 'Please enter username and password.' }
   }
@@ -31,15 +32,64 @@ export async function adminLogin (formData: FormData) {
     httpOnly: true,
     secure: process.env.NODE_ENV === 'production',
     sameSite: 'lax',
-    maxAge: 60 * 60 * 24 * 7, // 7 days
+    maxAge: 60 * 60 * 24 * 7,
     path: '/'
   })
+  redirect(redirectTo)
+}
+
+export async function adminLogout (formData: FormData) {
+  const redirectTo = (formData.get('redirectTo') as string) || '/admin'
+  const cookieStore = await cookies()
+  cookieStore.delete(getAdminCookieName())
+  redirect(redirectTo)
+}
+
+function slugify (name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\s-]/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+}
+
+export async function createEvent (formData: FormData) {
+  await requireAdmin()
+
+  const name = (formData.get('name') as string | null)?.trim()
+  if (!name) {
+    return { error: 'Please enter an event name.' }
+  }
+
+  const slug = slugify(name)
+  if (!slug) {
+    return { error: 'Invalid event name.' }
+  }
+
+  const [existing] = await db.select().from(events).where(eq(events.slug, slug)).limit(1)
+  if (existing) {
+    return { error: `An event with slug "${slug}" already exists.` }
+  }
+
+  await db.insert(events).values({ slug, name })
   redirect('/admin')
 }
 
-export async function adminLogout () {
-  const cookieStore = await cookies()
-  cookieStore.delete(getAdminCookieName())
+export async function deleteEvent (formData: FormData) {
+  await requireAdmin()
+
+  const slug = (formData.get('slug') as string | null)?.trim()
+  if (!slug) {
+    return { error: 'Invalid event.' }
+  }
+
+  await db.transaction(async (tx) => {
+    await tx.delete(allowedEmails).where(eq(allowedEmails.eventSlug, slug))
+    await tx.delete(referralCodes).where(eq(referralCodes.eventSlug, slug))
+    await tx.delete(events).where(eq(events.slug, slug))
+  })
+
   redirect('/admin')
 }
 
@@ -73,10 +123,15 @@ function extractEmailsFromRawText (text: string): string[] {
 export async function upsertAllowedEmail (formData: FormData) {
   await requireAdmin()
 
+  const eventSlug = (formData.get('eventSlug') as string | null) ?? ''
   const rawEmail = (formData.get('email') as string | null) ?? ''
   const rawName = (formData.get('name') as string | null) ?? ''
   const email = normalizeEmail(rawEmail)
   const name = rawName.trim()
+
+  if (!eventSlug) {
+    return { error: 'Invalid event.' }
+  }
 
   if (!email || !email.includes('@')) {
     return { error: 'Please enter a valid email address.' }
@@ -84,9 +139,10 @@ export async function upsertAllowedEmail (formData: FormData) {
 
   await db.insert(allowedEmails).values({
     email,
-    name: name || null
+    name: name || null,
+    eventSlug
   }).onConflictDoUpdate({
-    target: allowedEmails.email,
+    target: [allowedEmails.email, allowedEmails.eventSlug],
     set: { name: sql`excluded.name` }
   })
 
@@ -96,19 +152,32 @@ export async function upsertAllowedEmail (formData: FormData) {
 export async function deleteAllowedEmail (formData: FormData) {
   await requireAdmin()
 
+  const eventSlug = (formData.get('eventSlug') as string | null) ?? ''
   const rawEmail = (formData.get('email') as string | null) ?? ''
   const email = normalizeEmail(rawEmail)
+
+  if (!eventSlug) {
+    return { error: 'Invalid event.' }
+  }
 
   if (!email || !email.includes('@')) {
     return { error: 'Please enter a valid email address.' }
   }
 
-  await db.delete(allowedEmails).where(eq(allowedEmails.email, email))
+  await db.delete(allowedEmails).where(
+    and(eq(allowedEmails.email, email), eq(allowedEmails.eventSlug, eventSlug))
+  )
+
   return { success: `Removed ${email}` }
 }
 
 export async function uploadEmailsCsv (formData: FormData) {
   await requireAdmin()
+
+  const eventSlug = (formData.get('eventSlug') as string | null) ?? ''
+  if (!eventSlug) {
+    return { error: 'Invalid event.' }
+  }
 
   const file = formData.get('file') as File | null
   if (!file || file.size === 0) {
@@ -140,14 +209,14 @@ export async function uploadEmailsCsv (formData: FormData) {
       findColumn(row, 'email address') ??
       ''
     ).toLowerCase()
-    const name =
-      findColumn(row, 'name') ??
-      ([findColumn(row, 'first_name', 'firstname', 'first name'), findColumn(row, 'last_name', 'lastname', 'last name')]
+    const name = (
+      findColumn(row, 'name') ||
+      [findColumn(row, 'first_name', 'firstname', 'first name'), findColumn(row, 'last_name', 'lastname', 'last name')]
         .filter(Boolean)
-        .join(' ')
-        .trim() || '')
+        .join(' ') || ''
+    ).replace(/\s+/g, ' ').trim()
     if (email && email.includes('@')) {
-      if (!byEmail.has(email)) byEmail.set(email, name || '')
+      if (!byEmail.has(email)) byEmail.set(email, name)
     }
   }
 
@@ -162,28 +231,57 @@ export async function uploadEmailsCsv (formData: FormData) {
     return { error: 'No valid emails found. Use a CSV with an "email" column or a plain one-email-per-line file.' }
   }
 
-  const rows = Array.from(byEmail, ([email, name]) => ({ email, name: name || null }))
+  const rows = Array.from(byEmail, ([email, name]) => ({ email, name: name || null, eventSlug }))
 
   if (replace) {
     await db.transaction(async (tx) => {
-      await tx.delete(allowedEmails)
+      await tx.delete(allowedEmails).where(eq(allowedEmails.eventSlug, eventSlug))
       await tx.insert(allowedEmails).values(rows).onConflictDoUpdate({
-        target: allowedEmails.email,
+        target: [allowedEmails.email, allowedEmails.eventSlug],
         set: { name: sql`excluded.name` }
       })
     })
   } else {
     await db.insert(allowedEmails).values(rows).onConflictDoUpdate({
-      target: allowedEmails.email,
+      target: [allowedEmails.email, allowedEmails.eventSlug],
       set: { name: sql`excluded.name` }
     })
   }
 
-  redirect('/admin')
+  redirect(`/${eventSlug}/admin`)
+}
+
+function extractCodesFromText (raw: string): Array<{ code: string; url: string }> {
+  const seen = new Set<string>()
+  const entries: Array<{ code: string; url: string }> = []
+
+  for (const line of raw.split(/[\n\r]+/)) {
+    const trimmed = line.trim()
+    if (!trimmed) continue
+
+    let code = ''
+    const urlMatch = trimmed.match(/[?&]code=([A-Za-z0-9._~-]+)/i)
+    if (urlMatch) {
+      code = urlMatch[1].trim()
+    } else if (/^[A-Za-z0-9._~-]+$/.test(trimmed)) {
+      code = trimmed
+    }
+
+    if (!code || seen.has(code)) continue
+    seen.add(code)
+    entries.push({ code, url: `https://cursor.com/referral?code=${encodeURIComponent(code)}` })
+  }
+
+  return entries
 }
 
 export async function uploadCodesCsv (formData: FormData) {
   await requireAdmin()
+
+  const eventSlug = (formData.get('eventSlug') as string | null) ?? ''
+  if (!eventSlug) {
+    return { error: 'Invalid event.' }
+  }
 
   const file = formData.get('file') as File | null
   if (!file || file.size === 0) {
@@ -194,62 +292,136 @@ export async function uploadCodesCsv (formData: FormData) {
   }
 
   const replace = formData.get('replace') === 'on'
-
   const text = await file.text()
-  let records: Record<string, string>[]
-  try {
-    records = parse(text, { columns: true, skip_empty_lines: true, relax_column_count: true })
-  } catch {
-    return { error: 'Failed to parse CSV. Make sure it is a valid CSV file.' }
-  }
-
-  if (records.length === 0) {
-    return { error: 'CSV has no data rows.' }
-  }
 
   const entries: Array<{ code: string; url: string }> = []
   const seen = new Set<string>()
 
-  for (const row of records) {
-    const url = findColumn(row, 'url', 'link', 'referral_url', 'referral_link')
-    const codeOnly = findColumn(row, 'code', 'code_id', 'referral_code')
+  let records: Record<string, string>[] = []
+  try {
+    records = parse(text, { columns: true, skip_empty_lines: true, relax_column_count: true })
+  } catch {
+    // not a valid CSV with headers — fall through to raw text extraction
+  }
 
-    let code = ''
+  if (records.length > 0) {
+    for (const row of records) {
+      const url = findColumn(row, 'url', 'link', 'referral_url', 'referral_link')
+      const codeOnly = findColumn(row, 'code', 'code_id', 'referral_code')
 
-    if (url) {
-      const codeMatch = url.match(/[?&]code=([A-Za-z0-9._~-]+)/i)
-      code = (codeMatch?.[1] ?? '').trim()
-    } else if (codeOnly) {
-      code = codeOnly
+      let code = ''
+
+      if (url) {
+        const codeMatch = url.match(/[?&]code=([A-Za-z0-9._~-]+)/i)
+        code = (codeMatch?.[1] ?? '').trim()
+      } else if (codeOnly) {
+        code = codeOnly
+      }
+
+      if (!code) {
+        const values = Object.values(row).map((v) => v?.trim()).filter(Boolean)
+        for (const val of values) {
+          const m = val.match(/[?&]code=([A-Za-z0-9._~-]+)/i)
+          if (m) { code = m[1].trim(); break }
+          if (/^[A-Za-z0-9._~-]+$/.test(val) && val.length >= 6) { code = val; break }
+        }
+      }
+
+      if (!code || seen.has(code)) continue
+      seen.add(code)
+      entries.push({ code, url: `https://cursor.com/referral?code=${encodeURIComponent(code)}` })
     }
-
-    if (!code) continue
-    const resolvedUrl = `https://cursor.com/referral?code=${encodeURIComponent(code)}`
-    if (seen.has(code)) continue
-    seen.add(code)
-    entries.push({ code, url: resolvedUrl })
   }
 
   if (entries.length === 0) {
-    return { error: 'No valid codes found. CSV must have a "code" or "url" column. Other columns are ignored.' }
+    const fallback = extractCodesFromText(text)
+    entries.push(...fallback)
+  }
+
+  if (entries.length === 0) {
+    return { error: 'No valid codes found. Upload a CSV with codes, referral URLs, or one code/URL per line.' }
   }
 
   if (replace) {
     await db.transaction(async (tx) => {
-      await tx.delete(referralCodes)
+      await tx.delete(referralCodes).where(eq(referralCodes.eventSlug, eventSlug))
       await tx.insert(referralCodes).values(entries.map(({ code, url }) => ({
         code,
         url,
-        claimedByEmail: null
+        claimedByEmail: null,
+        eventSlug
       }))).onConflictDoNothing()
     })
   } else {
     await db.insert(referralCodes).values(entries.map(({ code, url }) => ({
       code,
       url,
-      claimedByEmail: null
+      claimedByEmail: null,
+      eventSlug
     }))).onConflictDoNothing()
   }
 
-  redirect('/admin')
+  redirect(`/${eventSlug}/admin`)
+}
+
+export async function pasteCodesRaw (formData: FormData) {
+  await requireAdmin()
+
+  const eventSlug = (formData.get('eventSlug') as string | null) ?? ''
+  if (!eventSlug) {
+    return { error: 'Invalid event.' }
+  }
+
+  const raw = (formData.get('codes') as string | null) ?? ''
+  if (!raw.trim()) {
+    return { error: 'Please paste at least one code or URL.' }
+  }
+
+  const replace = formData.get('replace') === 'on'
+  const lines = raw.split(/[\n\r]+/).map((l) => l.trim()).filter(Boolean)
+
+  const entries: Array<{ code: string; url: string }> = []
+  const seen = new Set<string>()
+
+  for (const line of lines) {
+    let code = ''
+
+    const urlMatch = line.match(/[?&]code=([A-Za-z0-9._~-]+)/i)
+    if (urlMatch) {
+      code = urlMatch[1].trim()
+    } else {
+      code = line.replace(/^https?:\/\//, '').trim()
+    }
+
+    if (!code) continue
+    if (seen.has(code)) continue
+    seen.add(code)
+    const resolvedUrl = `https://cursor.com/referral?code=${encodeURIComponent(code)}`
+    entries.push({ code, url: resolvedUrl })
+  }
+
+  if (entries.length === 0) {
+    return { error: 'No valid codes found. Paste one code or URL per line.' }
+  }
+
+  if (replace) {
+    await db.transaction(async (tx) => {
+      await tx.delete(referralCodes).where(eq(referralCodes.eventSlug, eventSlug))
+      await tx.insert(referralCodes).values(entries.map(({ code, url }) => ({
+        code,
+        url,
+        claimedByEmail: null,
+        eventSlug
+      }))).onConflictDoNothing()
+    })
+  } else {
+    await db.insert(referralCodes).values(entries.map(({ code, url }) => ({
+      code,
+      url,
+      claimedByEmail: null,
+      eventSlug
+    }))).onConflictDoNothing()
+  }
+
+  return { success: `Added ${entries.length} code${entries.length === 1 ? '' : 's'}.` }
 }

--- a/app/admin/admin-analytics.tsx
+++ b/app/admin/admin-analytics.tsx
@@ -13,7 +13,29 @@ import {
   type SortingState,
   type ColumnFiltersState
 } from '@tanstack/react-table'
-import { useMemo, useState } from 'react'
+import { useCallback, useMemo, useState } from 'react'
+
+function CopyButton ({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false)
+
+  const handleCopy = useCallback(() => {
+    navigator.clipboard.writeText(text).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    })
+  }, [text])
+
+  return (
+    <button
+      type="button"
+      onClick={handleCopy}
+      className="shrink-0 rounded border border-zinc-600 bg-zinc-800 px-1.5 py-0.5 text-xs text-zinc-400 hover:bg-zinc-700 hover:text-white"
+      title="Copy URL"
+    >
+      {copied ? 'Copied!' : 'Copy'}
+    </button>
+  )
+}
 
 type AnalyticsResponse = {
   summary: {
@@ -32,8 +54,8 @@ type AnalyticsResponse = {
   emails: Array<{ email: string; name: string | null }>
 }
 
-async function fetchAnalytics (): Promise<AnalyticsResponse> {
-  const res = await fetch('/api/admin/analytics')
+async function fetchAnalytics (eventSlug: string): Promise<AnalyticsResponse> {
+  const res = await fetch(`/api/admin/analytics?slug=${encodeURIComponent(eventSlug)}`)
   if (!res.ok) {
     const err = await res.json().catch(() => ({}))
     throw new Error(err?.error ?? `HTTP ${res.status}`)
@@ -93,16 +115,22 @@ function CodesDataTable ({ data }: { data: AnalyticsResponse['codes'] }) {
     () => [
       columnHelper.accessor('code', {
         header: 'Code URL',
-        cell: (info) => (
-          <a
-            href={`https://cursor.com/referral?code=${encodeURIComponent(info.getValue())}`}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-mono text-zinc-200 underline hover:text-white"
-          >
-            {`https://cursor.com/referral?code=${info.getValue()}`}
-          </a>
-        )
+        cell: (info) => {
+          const url = `https://cursor.com/referral?code=${encodeURIComponent(info.getValue())}`
+          return (
+            <span className="flex items-center gap-2">
+              <a
+                href={url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="font-mono text-zinc-200 underline hover:text-white"
+              >
+                {url}
+              </a>
+              <CopyButton text={url} />
+            </span>
+          )
+        }
       }),
       columnHelper.accessor('status', {
         header: 'Status',
@@ -153,12 +181,29 @@ function CodesDataTable ({ data }: { data: AnalyticsResponse['codes'] }) {
 
   const statusFilter = columnFilters.find((f) => f.id === 'status')?.value as string | undefined
   const availableCount = data.filter((row) => row.status === 'available').length
+  const [allCopied, setAllCopied] = useState(false)
+
+  const copyAllUrls = useCallback(() => {
+    const urls = data.map((row) => `https://cursor.com/referral?code=${encodeURIComponent(row.code)}`)
+    navigator.clipboard.writeText(urls.join('\n')).then(() => {
+      setAllCopied(true)
+      setTimeout(() => setAllCopied(false), 1500)
+    })
+  }, [data])
 
   return (
     <div className="overflow-hidden rounded-lg border border-zinc-600/60 bg-zinc-800/50">
       <div className="flex flex-col gap-3 border-b border-zinc-600/60 px-4 py-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
         <div className="flex items-center gap-3">
           <h2 className="text-sm font-semibold text-zinc-200">Referral Codes</h2>
+          <button
+            type="button"
+            onClick={copyAllUrls}
+            disabled={data.length === 0}
+            className="rounded border border-zinc-600 bg-zinc-800 px-2.5 py-1 text-xs text-zinc-300 hover:bg-zinc-700 disabled:opacity-50"
+          >
+            {allCopied ? 'Copied!' : `Copy all URLs (${data.length})`}
+          </button>
           <button
             type="button"
             onClick={() => downloadAvailableCreditsCsv(data)}
@@ -442,10 +487,10 @@ function EmailsDataTable ({ data }: { data: AnalyticsResponse['emails'] }) {
   )
 }
 
-export function AdminAnalytics () {
+export function AdminAnalytics ({ eventSlug }: { eventSlug: string }) {
   const { data, isLoading, isError, error, refetch } = useQuery({
-    queryKey: ['admin', 'analytics'],
-    queryFn: fetchAnalytics
+    queryKey: ['admin', 'analytics', eventSlug],
+    queryFn: () => fetchAnalytics(eventSlug)
   })
 
   if (isLoading) {

--- a/app/admin/admin-login-form.tsx
+++ b/app/admin/admin-login-form.tsx
@@ -4,7 +4,7 @@ import { useActionState } from 'react'
 
 type LoginAction = (formData: FormData) => Promise<{ error?: string } | void>
 
-export function AdminLoginForm ({ action }: { action: LoginAction }) {
+export function AdminLoginForm ({ action, redirectTo }: { action: LoginAction; redirectTo?: string }) {
   const [state, formAction] = useActionState(
     async (_: void | { error?: string } | null, formData: FormData) => {
       return action(formData)
@@ -14,6 +14,7 @@ export function AdminLoginForm ({ action }: { action: LoginAction }) {
 
   return (
     <form action={formAction} className="flex flex-col gap-4">
+      {redirectTo && <input type="hidden" name="redirectTo" value={redirectTo} />}
       <div>
         <label className="sr-only" htmlFor="admin-username">
           Username

--- a/app/admin/create-event-form.tsx
+++ b/app/admin/create-event-form.tsx
@@ -1,0 +1,46 @@
+'use client'
+
+import { useActionState } from 'react'
+
+type CreateEventAction = (formData: FormData) => Promise<{ error?: string } | void>
+
+export function CreateEventForm ({ action }: { action: CreateEventAction }) {
+  const [state, formAction, isPending] = useActionState(
+    async (_: void | { error?: string } | null, formData: FormData) => {
+      return action(formData)
+    },
+    null as { error?: string } | null
+  )
+
+  return (
+    <form action={formAction} className="rounded-lg border border-zinc-600/60 bg-zinc-800/50 p-4">
+      <p className="mb-3 text-sm font-semibold text-zinc-200">Create New Event</p>
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex-1">
+          <span className="mb-1 block text-xs text-zinc-400">Event name</span>
+          <input
+            type="text"
+            name="name"
+            placeholder="e.g. Cafe Cursor Nairobi"
+            required
+            disabled={isPending}
+            className="w-full rounded-lg border border-zinc-600 bg-zinc-900 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-500 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+          />
+        </label>
+        <button
+          type="submit"
+          disabled={isPending}
+          className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-600 disabled:opacity-50"
+        >
+          {isPending ? 'Creating...' : 'Create Event'}
+        </button>
+      </div>
+      <p className="mt-2 text-xs text-zinc-500">
+        Slug is auto-generated from the name (e.g. &quot;Cafe Cursor Nairobi&quot; &rarr; /cafe-cursor-nairobi)
+      </p>
+      {state?.error && (
+        <p className="mt-3 text-sm text-red-400" role="alert">{state.error}</p>
+      )}
+    </form>
+  )
+}

--- a/app/admin/csv-upload.tsx
+++ b/app/admin/csv-upload.tsx
@@ -8,11 +8,13 @@ export function CsvUpload ({
   action,
   label,
   hint,
+  eventSlug,
   allowReplace = true
 }: {
   action: UploadAction
   label: string
   hint: string
+  eventSlug: string
   allowReplace?: boolean
 }) {
   const formRef = useRef<HTMLFormElement>(null)
@@ -30,6 +32,7 @@ export function CsvUpload ({
       action={formAction}
       className="rounded-lg border border-zinc-600/60 bg-zinc-800/50 p-4"
     >
+      <input type="hidden" name="eventSlug" value={eventSlug} />
       <p className="mb-1 text-sm font-semibold text-zinc-200">{label}</p>
       <p className="mb-3 text-xs text-zinc-500">{hint}</p>
 

--- a/app/admin/delete-event-button.tsx
+++ b/app/admin/delete-event-button.tsx
@@ -1,0 +1,43 @@
+'use client'
+
+import { useActionState } from 'react'
+
+type DeleteEventAction = (formData: FormData) => Promise<{ error?: string } | void>
+
+export function DeleteEventButton ({
+  slug,
+  name,
+  action
+}: {
+  slug: string
+  name: string
+  action: DeleteEventAction
+}) {
+  const [state, formAction, isPending] = useActionState(
+    async (_: void | { error?: string } | null, formData: FormData) => {
+      return action(formData)
+    },
+    null as { error?: string } | null
+  )
+
+  return (
+    <form action={formAction}>
+      <input type="hidden" name="slug" value={slug} />
+      <button
+        type="submit"
+        disabled={isPending}
+        className="rounded-lg border border-red-600/60 bg-red-900/20 px-3 py-1.5 text-sm font-medium text-red-400 transition-colors hover:bg-red-900/40 hover:text-red-300 disabled:opacity-50"
+        onClick={(e) => {
+          if (!confirm(`Delete "${name}" and all its codes/emails?`)) {
+            e.preventDefault()
+          }
+        }}
+      >
+        {isPending ? 'Deleting...' : 'Delete'}
+      </button>
+      {state?.error && (
+        <p className="mt-1 text-xs text-red-400">{state.error}</p>
+      )}
+    </form>
+  )
+}

--- a/app/admin/email-manager.tsx
+++ b/app/admin/email-manager.tsx
@@ -8,10 +8,12 @@ type EmailAction = (formData: FormData) => Promise<EmailActionResult>
 
 export function EmailManager ({
   upsertAction,
-  deleteAction
+  deleteAction,
+  eventSlug
 }: {
   upsertAction: EmailAction
   deleteAction: EmailAction
+  eventSlug: string
 }) {
   const queryClient = useQueryClient()
   const upsertFormRef = useRef<HTMLFormElement>(null)
@@ -53,6 +55,7 @@ export function EmailManager ({
         action={upsertFormAction}
         className="mb-4"
       >
+        <input type="hidden" name="eventSlug" value={eventSlug} />
         <div className="grid gap-3 sm:grid-cols-[1fr_1fr_auto] sm:items-center">
           <input
             type="email"
@@ -90,6 +93,7 @@ export function EmailManager ({
         action={deleteFormAction}
         className="border-t border-zinc-700/60 pt-4"
       >
+        <input type="hidden" name="eventSlug" value={eventSlug} />
         <div className="grid gap-3 sm:grid-cols-[1fr_auto] sm:items-center">
           <input
             type="email"

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,20 +1,16 @@
 import { cookies } from 'next/headers'
 import Image from 'next/image'
 import Link from 'next/link'
+import { and, eq, isNull } from 'drizzle-orm'
 import { getAdminCookieName, verifyAdminToken } from '@/lib/admin'
-import {
-  adminLogin,
-  adminLogout,
-  uploadEmailsCsv,
-  uploadCodesCsv,
-  upsertAllowedEmail,
-  deleteAllowedEmail
-} from './actions'
-import { AdminAnalytics } from './admin-analytics'
+import { db } from '@/lib/db'
+import { events, referralCodes } from '@/lib/db/schema'
+import { adminLogin, adminLogout, createEvent, deleteEvent } from './actions'
 import { AdminLoginForm } from './admin-login-form'
-import { EmailManager } from './email-manager'
-import { AdminQueryProvider } from './query-provider'
-import { CsvUpload } from './csv-upload'
+import { CreateEventForm } from './create-event-form'
+import { DeleteEventButton } from './delete-event-button'
+
+export const dynamic = 'force-dynamic'
 
 export default async function AdminPage () {
   const cookieStore = await cookies()
@@ -38,7 +34,7 @@ export default async function AdminPage () {
           <AdminLoginForm action={adminLogin} />
           <p className="mt-6 text-center text-xs text-zinc-500">
             <Link href="/" className="underline hover:text-zinc-400">
-              Back to redeem
+              Back to portal
             </Link>
           </p>
         </main>
@@ -46,9 +42,24 @@ export default async function AdminPage () {
     )
   }
 
+  const allEvents = await db.select().from(events)
+  const eventsWithStats = await Promise.all(
+    allEvents.map(async (event) => {
+      const total = await db.select().from(referralCodes).where(eq(referralCodes.eventSlug, event.slug))
+      const available = await db.select().from(referralCodes).where(
+        and(eq(referralCodes.eventSlug, event.slug), isNull(referralCodes.claimedByEmail))
+      )
+      return {
+        ...event,
+        totalCodes: total.length,
+        availableCodes: available.length
+      }
+    })
+  )
+
   return (
     <div className="min-h-screen bg-[#1a1a1a] px-4 py-12 font-sans text-white">
-      <div className="mx-auto max-w-5xl">
+      <div className="mx-auto max-w-3xl">
         <header className="mb-8 flex flex-wrap items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <Image
@@ -58,12 +69,12 @@ export default async function AdminPage () {
               height={40}
             />
             <div>
-            <h1 className="text-2xl font-bold tracking-tight text-zinc-100">
-              Admin Dashboard
-            </h1>
-            <p className="mt-1 text-sm text-zinc-400">
-              Manage codes, emails, and CSV uploads
-            </p>
+              <h1 className="text-2xl font-bold tracking-tight text-zinc-100">
+                Events Manager
+              </h1>
+              <p className="mt-1 text-sm text-zinc-400">
+                Create and manage credit disbursement events
+              </p>
             </div>
           </div>
           <form action={adminLogout}>
@@ -76,31 +87,49 @@ export default async function AdminPage () {
           </form>
         </header>
 
-        <AdminQueryProvider>
-          <div className="space-y-8">
-            <EmailManager
-              upsertAction={upsertAllowedEmail}
-              deleteAction={deleteAllowedEmail}
-            />
-            <div className="grid gap-4 sm:grid-cols-2">
-              <CsvUpload
-                action={uploadEmailsCsv}
-                label="Bulk Upload Emails"
-                hint="Columns: email, name (or one email per line)."
-              />
-              <CsvUpload
-                action={uploadCodesCsv}
-                label="Bulk Upload Codes"
-                hint="Columns: code or url."
-              />
+        <CreateEventForm action={createEvent} />
+
+        <div className="mt-8 space-y-4">
+          <h2 className="text-lg font-semibold text-zinc-200">Events</h2>
+          {eventsWithStats.length === 0 && (
+            <p className="text-sm text-zinc-500">No events yet. Create one above.</p>
+          )}
+          {eventsWithStats.map((event) => (
+            <div
+              key={event.slug}
+              className="flex flex-wrap items-center justify-between gap-4 rounded-lg border border-zinc-600/60 bg-zinc-800/50 px-5 py-4"
+            >
+              <div>
+                <p className="font-semibold text-zinc-100">{event.name}</p>
+                <p className="mt-0.5 text-xs text-zinc-500">/{event.slug}</p>
+              </div>
+              <div className="flex items-center gap-4">
+                <div className="text-right">
+                  <span className="text-sm text-zinc-300">
+                    <span className="font-medium text-orange-500">{event.availableCodes}</span>
+                    <span className="text-zinc-500">/{event.totalCodes}</span>
+                  </span>
+                  <p className="text-xs text-zinc-500">available</p>
+                </div>
+                <Link
+                  href={`/${event.slug}/admin`}
+                  className="rounded-lg border border-zinc-600 bg-zinc-800 px-3 py-1.5 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white"
+                >
+                  Manage
+                </Link>
+                <DeleteEventButton
+                  slug={event.slug}
+                  name={event.name}
+                  action={deleteEvent}
+                />
+              </div>
             </div>
-            <AdminAnalytics />
-          </div>
-        </AdminQueryProvider>
+          ))}
+        </div>
 
         <p className="mt-8 text-center text-xs text-zinc-500">
           <Link href="/" className="underline hover:text-zinc-400">
-            Back to redeem
+            Back to portal
           </Link>
         </p>
       </div>

--- a/app/admin/paste-codes.tsx
+++ b/app/admin/paste-codes.tsx
@@ -1,0 +1,139 @@
+'use client'
+
+import { useQueryClient } from '@tanstack/react-query'
+import { useActionState, useCallback, useEffect, useRef, useState } from 'react'
+
+type PasteAction = (formData: FormData) => Promise<{ error?: string; success?: string } | void>
+
+export function PasteCodes ({
+  action,
+  eventSlug
+}: {
+  action: PasteAction
+  eventSlug: string
+}) {
+  const queryClient = useQueryClient()
+  const [isOpen, setIsOpen] = useState(false)
+  const formRef = useRef<HTMLFormElement>(null)
+  const dialogRef = useRef<HTMLDialogElement>(null)
+
+  const [state, formAction, isPending] = useActionState(
+    async (_: void | { error?: string; success?: string } | null, formData: FormData) => {
+      const result = await action(formData)
+      if (result && 'success' in result) {
+        formRef.current?.reset()
+        queryClient.invalidateQueries({ queryKey: ['admin', 'analytics'] })
+        setIsOpen(false)
+      }
+      return result ?? {}
+    },
+    null as { error?: string; success?: string } | null
+  )
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+
+  useEffect(() => {
+    if (isOpen) {
+      dialogRef.current?.showModal()
+    } else {
+      dialogRef.current?.close()
+    }
+  }, [isOpen])
+
+  useEffect(() => {
+    const dialog = dialogRef.current
+    if (!dialog) return
+    const handleClose = () => setIsOpen(false)
+    dialog.addEventListener('close', handleClose)
+    return () => dialog.removeEventListener('close', handleClose)
+  }, [])
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={open}
+        className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a]"
+      >
+        Paste Codes
+      </button>
+
+      <dialog
+        ref={dialogRef}
+        className="w-full max-w-lg rounded-xl border border-zinc-600/60 bg-[#1a1a1a] p-0 text-white shadow-2xl backdrop:bg-black/60"
+      >
+        <div className="p-6">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="text-lg font-semibold text-zinc-100">Paste Codes</h2>
+            <button
+              type="button"
+              onClick={close}
+              className="rounded-lg p-1 text-zinc-400 transition-colors hover:bg-zinc-800 hover:text-white"
+            >
+              <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round">
+                <path d="M5 5l10 10M15 5L5 15" />
+              </svg>
+            </button>
+          </div>
+
+          <p className="mb-4 text-sm text-zinc-400">
+            Paste codes or referral URLs, one per line.
+          </p>
+
+          <form ref={formRef} action={formAction}>
+            <input type="hidden" name="eventSlug" value={eventSlug} />
+
+            <textarea
+              name="codes"
+              rows={8}
+              required
+              disabled={isPending}
+              autoFocus
+              placeholder={'https://cursor.com/referral?code=abc123\nhttps://cursor.com/referral?code=def456\nor just raw codes:\nabc123\ndef456'}
+              className="mb-4 w-full rounded-lg border border-zinc-600 bg-zinc-900 px-3 py-2 font-mono text-sm text-zinc-200 placeholder-zinc-600 focus:border-zinc-500 focus:outline-none focus:ring-1 focus:ring-zinc-500"
+            />
+
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  name="replace"
+                  value="on"
+                  disabled={isPending}
+                  className="rounded border-zinc-600 bg-zinc-800 text-orange-500 focus:ring-orange-500"
+                />
+                <span className="text-sm text-zinc-400">Replace existing codes</span>
+              </label>
+
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={close}
+                  disabled={isPending}
+                  className="rounded-lg border border-zinc-600 bg-zinc-800 px-4 py-2 text-sm font-medium text-zinc-300 transition-colors hover:bg-zinc-700 hover:text-white disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="submit"
+                  disabled={isPending}
+                  className="rounded-lg bg-orange-500 px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-orange-600 disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a]"
+                >
+                  {isPending ? 'Adding...' : 'Add Codes'}
+                </button>
+              </div>
+            </div>
+
+            {state?.error && (
+              <p className="mt-3 text-sm text-red-400" role="alert">{state.error}</p>
+            )}
+            {state?.success && (
+              <p className="mt-3 text-sm text-emerald-400">{state.success}</p>
+            )}
+          </form>
+        </div>
+      </dialog>
+    </>
+  )
+}

--- a/app/api/admin/analytics/route.ts
+++ b/app/api/admin/analytics/route.ts
@@ -1,9 +1,9 @@
-import { NextResponse } from 'next/server'
+import { NextResponse, type NextRequest } from 'next/server'
 import { cookies } from 'next/headers'
+import { eq, desc } from 'drizzle-orm'
 import { getAdminCookieName, verifyAdminToken } from '@/lib/admin'
 import { db } from '@/lib/db'
 import { referralCodes, allowedEmails } from '@/lib/db/schema'
-import { desc } from 'drizzle-orm'
 
 type AnalyticsPayload = {
   summary: {
@@ -25,20 +25,16 @@ type AnalyticsPayload = {
   }>
 }
 
-const ANALYTICS_CACHE_TTL_MS = 15 * 1000
-
-let analyticsCache: { data: AnalyticsPayload; expiresAt: number } | null = null
-
-export async function GET () {
+export async function GET (request: NextRequest) {
   const cookieStore = await cookies()
   const token = cookieStore.get(getAdminCookieName())?.value
   if (!(await verifyAdminToken(token))) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
   }
 
-  const now = Date.now()
-  if (analyticsCache && analyticsCache.expiresAt > now) {
-    return NextResponse.json(analyticsCache.data)
+  const slug = request.nextUrl.searchParams.get('slug')
+  if (!slug) {
+    return NextResponse.json({ error: 'Missing slug parameter' }, { status: 400 })
   }
 
   try {
@@ -51,6 +47,7 @@ export async function GET () {
           claimedByEmail: referralCodes.claimedByEmail
         })
         .from(referralCodes)
+        .where(eq(referralCodes.eventSlug, slug))
         .orderBy(desc(referralCodes.id)),
       db
         .select({
@@ -58,6 +55,7 @@ export async function GET () {
           name: allowedEmails.name
         })
         .from(allowedEmails)
+        .where(eq(allowedEmails.eventSlug, slug))
     ])
 
     const redeemed = codes.filter((r) => r.claimedByEmail !== null)
@@ -78,11 +76,6 @@ export async function GET () {
         claimedByEmail: r.claimedByEmail ?? null
       })),
       emails
-    }
-
-    analyticsCache = {
-      data: payload,
-      expiresAt: now + ANALYTICS_CACHE_TTL_MS
     }
 
     return NextResponse.json(payload)

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,30 +1,31 @@
-'use client'
-
 import Image from 'next/image'
-import { useActionState, useEffect, useState } from 'react'
-import { redeemCode, getCodeCounts, type RedeemResult } from './actions/redeem'
+import Link from 'next/link'
+import { and, eq, isNull } from 'drizzle-orm'
+import { db } from '@/lib/db'
+import { events, referralCodes } from '@/lib/db/schema'
 
-export default function Home () {
-  const [result, formAction, isPending] = useActionState(redeemCode, null as RedeemResult | null)
-  const [counts, setCounts] = useState<{ available: number; total: number } | null>(null)
+export const dynamic = 'force-dynamic'
 
-  const refreshCounts = () => {
-    getCodeCounts().then(setCounts)
-  }
+export default async function Home () {
+  const allEvents = await db.select().from(events)
 
-  useEffect(() => {
-    refreshCounts()
-  }, [])
-
-  useEffect(() => {
-    if (result?.success) {
-      refreshCounts()
-    }
-  }, [result?.success])
+  const eventsWithStats = await Promise.all(
+    allEvents.map(async (event) => {
+      const total = await db.select().from(referralCodes).where(eq(referralCodes.eventSlug, event.slug))
+      const available = await db.select().from(referralCodes).where(
+        and(eq(referralCodes.eventSlug, event.slug), isNull(referralCodes.claimedByEmail))
+      )
+      return {
+        ...event,
+        totalCodes: total.length,
+        availableCodes: available.length
+      }
+    })
+  )
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center bg-[#1a1a1a] px-4 py-16 font-sans text-white">
-      <main className="flex w-full max-w-md flex-col items-center gap-8">
+      <main className="flex w-full max-w-lg flex-col items-center gap-8">
         <div className="flex flex-col items-center gap-4">
           <Image
             src="/CUBE_2D_DARK.png"
@@ -37,73 +38,35 @@ export default function Home () {
             className="text-center text-2xl font-bold tracking-tight"
             style={{ fontFamily: 'var(--font-geist-pixel-square)' }}
           >
-            Cursor Pro Redeem Codes
+            Cursor Pro Credits Portal
           </h1>
           <p className="text-center text-sm font-normal text-zinc-400">
-            Redeem your Cursor Pro access code
+            Select an event to redeem your Cursor Pro access code
           </p>
         </div>
 
-        <div className="flex w-full flex-col items-center gap-6">
-          <div className="rounded-lg border border-zinc-600/60 bg-zinc-800/50 px-4 py-2">
-            <span className="text-sm text-zinc-300">Available: </span>
-            <span className="text-sm font-medium text-orange-500">
-              {counts ? `${counts.available}/${counts.total}` : '–/–'}
-            </span>
-          </div>
-
-          {result?.success && (
-            <div className="w-full rounded-lg border border-green-600/60 bg-green-900/20 px-4 py-3 text-sm text-green-300">
-              <p className="font-medium">Code assigned successfully. A confirmation email was sent.</p>
-              <p className="mt-1 break-all">
-                <a
-                  href={result.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline hover:text-green-200"
-                >
-                  {result.url}
-                </a>
-              </p>
-              <p className="mt-1 text-zinc-400">Code: {result.code}</p>
-            </div>
+        <div className="flex w-full flex-col gap-4">
+          {eventsWithStats.length === 0 && (
+            <p className="text-center text-zinc-500">No events available yet.</p>
           )}
-
-          {result && !result.success && (
-            <div
-              className="w-full rounded-lg border border-red-600/60 bg-red-900/20 px-4 py-3 text-sm text-red-300"
-              role="alert"
+          {eventsWithStats.map((event) => (
+            <Link
+              key={event.slug}
+              href={`/${event.slug}`}
+              className="rounded-lg border border-zinc-600/60 bg-zinc-800/50 px-5 py-4 transition-colors hover:border-orange-500/60 hover:bg-zinc-800"
             >
-              {result.error}
-            </div>
-          )}
-
-          <form
-            action={formAction}
-            className="flex w-full flex-col gap-4"
-          >
-            <input
-              type="email"
-              name="email"
-              placeholder="Email"
-              className="w-full rounded-lg border border-zinc-600 bg-zinc-800/80 px-4 py-3 text-white placeholder:text-zinc-500 focus:border-orange-500 focus:outline-none focus:ring-1 focus:ring-orange-500"
-              aria-label="Email"
-              required
-              disabled={isPending}
-            />
-            <button
-              type="submit"
-              disabled={isPending}
-              className="w-full rounded-lg bg-orange-500 py-3 font-semibold text-white transition-colors hover:bg-orange-600 focus:outline-none focus:ring-2 focus:ring-orange-500 focus:ring-offset-2 focus:ring-offset-[#1a1a1a] disabled:opacity-60"
-            >
-              {isPending ? 'Redeeming…' : 'Redeem Code'}
-            </button>
-          </form>
+              <p className="font-semibold text-zinc-100">{event.name}</p>
+              <p className="mt-0.5 text-xs text-zinc-500">/{event.slug}</p>
+            </Link>
+          ))}
         </div>
 
-        <p className="text-center text-xs text-zinc-500">
-          cursor pro codes by cursor kenya community
-        </p>
+        <Link
+          href="/admin"
+          className="text-xs text-zinc-500 underline hover:text-zinc-400"
+        >
+          Admin
+        </Link>
       </main>
     </div>
   )

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -1,16 +1,28 @@
-import { pgTable, text, serial } from 'drizzle-orm/pg-core'
+import { pgTable, text, serial, timestamp, primaryKey, unique } from 'drizzle-orm/pg-core'
+
+export const events = pgTable('events', {
+  slug: text('slug').primaryKey().notNull(),
+  name: text('name').notNull(),
+  createdAt: timestamp('created_at').defaultNow().notNull()
+})
 
 export const allowedEmails = pgTable('allowed_emails', {
-  email: text('email').primaryKey().notNull(),
-  name: text('name')
-})
+  email: text('email').notNull(),
+  name: text('name'),
+  eventSlug: text('event_slug').notNull()
+}, (t) => [
+  primaryKey({ columns: [t.email, t.eventSlug] })
+])
 
 export const referralCodes = pgTable('referral_codes', {
   id: serial('id').primaryKey(),
-  code: text('code').notNull().unique(),
+  code: text('code').notNull(),
   url: text('url').notNull(),
-  claimedByEmail: text('claimed_by_email')
-})
+  claimedByEmail: text('claimed_by_email'),
+  eventSlug: text('event_slug').notNull()
+}, (t) => [
+  unique().on(t.code, t.eventSlug)
+])
 
 export const adminUsers = pgTable('admin_users', {
   username: text('username').primaryKey().notNull(),

--- a/scripts/migrate-events.ts
+++ b/scripts/migrate-events.ts
@@ -1,0 +1,46 @@
+import path from 'node:path'
+import { config } from 'dotenv'
+import { neon } from '@neondatabase/serverless'
+
+config({ path: path.resolve(process.cwd(), '.env.local') })
+
+const sql = neon(process.env.DATABASE_URL!)
+
+async function migrate () {
+  console.log('Creating events table...')
+  await sql`
+    CREATE TABLE IF NOT EXISTS events (
+      slug TEXT PRIMARY KEY NOT NULL,
+      name TEXT NOT NULL,
+      created_at TIMESTAMP DEFAULT NOW() NOT NULL
+    )
+  `
+
+  console.log('Inserting default event...')
+  await sql`
+    INSERT INTO events (slug, name)
+    VALUES ('cursor-ke-pwani', 'Cursor KE Pwani')
+    ON CONFLICT DO NOTHING
+  `
+
+  console.log('Adding event_slug to allowed_emails...')
+  await sql`ALTER TABLE allowed_emails ADD COLUMN IF NOT EXISTS event_slug TEXT`
+  await sql`UPDATE allowed_emails SET event_slug = 'cursor-ke-pwani' WHERE event_slug IS NULL`
+  await sql`ALTER TABLE allowed_emails ALTER COLUMN event_slug SET NOT NULL`
+
+  console.log('Changing allowed_emails PK to composite (email, event_slug)...')
+  await sql`ALTER TABLE allowed_emails DROP CONSTRAINT IF EXISTS allowed_emails_pkey`
+  await sql`ALTER TABLE allowed_emails ADD PRIMARY KEY (email, event_slug)`
+
+  console.log('Adding event_slug to referral_codes...')
+  await sql`ALTER TABLE referral_codes ADD COLUMN IF NOT EXISTS event_slug TEXT`
+  await sql`UPDATE referral_codes SET event_slug = 'cursor-ke-pwani' WHERE event_slug IS NULL`
+  await sql`ALTER TABLE referral_codes ALTER COLUMN event_slug SET NOT NULL`
+
+  console.log('Migration complete!')
+}
+
+migrate().catch((err) => {
+  console.error('Migration failed:', err)
+  process.exit(1)
+})


### PR DESCRIPTION
## Summary

- Add multi-event architecture with `events` table and per-event scoping for emails and referral codes
- Add event CRUD (create/delete) with slug-based routing (`/[slug]`, `/[slug]/admin`)
- Add paste codes dialog for bulk code entry
- Fix dirty Luma CSV handling: name fallback bug (`??` to `||`) so empty `name` fields correctly use `first_name`/`last_name`, plus whitespace normalization
- Refactor admin page to list and manage multiple events with stats
- Add migration script for existing data

## Test plan

- [ ] Upload a dirty Luma CSV (24+ columns) and verify emails and names are correctly extracted
- [ ] Verify rows with empty `name` but populated `first_name`/`last_name` get the concatenated name
- [ ] Verify names with trailing whitespace are cleaned up
- [ ] Create and delete events from the admin dashboard
- [ ] Paste codes via the new dialog and confirm they appear in analytics
- [ ] Redeem a code on a per-event page (`/[slug]`)

Closes #3